### PR TITLE
Fix build with GNU make 4.3 and GCC 10

### DIFF
--- a/make/common/MakeBase.gmk
+++ b/make/common/MakeBase.gmk
@@ -973,15 +973,16 @@ DependOnVariableFileName = \
 # Param 2 - (optional) name of file to store value in
 DependOnVariableHelper = \
     $(strip \
-        $(eval -include $(call DependOnVariableFileName, $1, $2)) \
+        $(eval $1_filename := $(call DependOnVariableFileName, $1, $2)) \
+        $(if $(wildcard $($1_filename)), $(eval include $($1_filename))) \
         $(if $(call equals, $(strip $($1)), $(strip $($1_old))),,\
-          $(call MakeDir, $(dir $(call DependOnVariableFileName, $1, $2))) \
+          $(call MakeDir, $(dir $($1_filename))) \
           $(if $(findstring $(LOG_LEVEL), trace), \
               $(info NewVariable $1: >$(strip $($1))<) \
               $(info OldVariable $1: >$(strip $($1_old))<)) \
           $(call WriteFile, $1_old:=$(call DoubleDollar,$(call EscapeHash,$($1))), \
-              $(call DependOnVariableFileName, $1, $2))) \
-        $(call DependOnVariableFileName, $1, $2) \
+              $($1_filename))) \
+        $($1_filename) \
     )
 
 # Main macro

--- a/src/java.base/unix/native/libjava/childproc.c
+++ b/src/java.base/unix/native/libjava/childproc.c
@@ -33,6 +33,8 @@
 
 #include "childproc.h"
 
+const char * const *parentPathv;
+
 
 ssize_t
 restartableWrite(int fd, const void *buf, size_t count)

--- a/src/java.base/unix/native/libjava/childproc.h
+++ b/src/java.base/unix/native/libjava/childproc.h
@@ -118,7 +118,7 @@ typedef struct _SpawnInfo {
  * The cached and split version of the JDK's effective PATH.
  * (We don't support putenv("PATH=...") in native code)
  */
-const char * const *parentPathv;
+extern const char * const *parentPathv;
 
 ssize_t restartableWrite(int fd, const void *buf, size_t count);
 int restartableDup2(int fd_from, int fd_to);

--- a/src/java.security.jgss/share/native/libj2gss/NativeFunc.c
+++ b/src/java.security.jgss/share/native/libj2gss/NativeFunc.c
@@ -27,6 +27,9 @@
 #include <stdlib.h>
 #include "NativeFunc.h"
 
+/* global GSS function table */
+GSS_FUNCTION_TABLE_PTR ftab;
+
 /* standard GSS method names (ordering is from mapfile) */
 static const char RELEASE_NAME[]                = "gss_release_name";
 static const char IMPORT_NAME[]                 = "gss_import_name";

--- a/src/java.security.jgss/share/native/libj2gss/NativeFunc.h
+++ b/src/java.security.jgss/share/native/libj2gss/NativeFunc.h
@@ -277,6 +277,6 @@ typedef struct GSS_FUNCTION_TABLE {
 typedef GSS_FUNCTION_TABLE *GSS_FUNCTION_TABLE_PTR;
 
 /* global GSS function table */
-GSS_FUNCTION_TABLE_PTR ftab;
+extern GSS_FUNCTION_TABLE_PTR ftab;
 
 #endif

--- a/src/jdk.sctp/unix/native/libsctp/Sctp.h
+++ b/src/jdk.sctp/unix/native/libsctp/Sctp.h
@@ -322,12 +322,12 @@ typedef int sctp_peeloff_func(int sock, sctp_assoc_t id);
 
 #endif /* __linux__ */
 
-sctp_getladdrs_func* nio_sctp_getladdrs;
-sctp_freeladdrs_func* nio_sctp_freeladdrs;
-sctp_getpaddrs_func* nio_sctp_getpaddrs;
-sctp_freepaddrs_func* nio_sctp_freepaddrs;
-sctp_bindx_func* nio_sctp_bindx;
-sctp_peeloff_func* nio_sctp_peeloff;
+extern sctp_getladdrs_func* nio_sctp_getladdrs;
+extern sctp_freeladdrs_func* nio_sctp_freeladdrs;
+extern sctp_getpaddrs_func* nio_sctp_getpaddrs;
+extern sctp_freepaddrs_func* nio_sctp_freepaddrs;
+extern sctp_bindx_func* nio_sctp_bindx;
+extern sctp_peeloff_func* nio_sctp_peeloff;
 
 jboolean loadSocketExtensionFuncs(JNIEnv* env);
 

--- a/src/jdk.sctp/unix/native/libsctp/SctpNet.c
+++ b/src/jdk.sctp/unix/native/libsctp/SctpNet.c
@@ -43,6 +43,13 @@ static jmethodID isaCtrID = 0;
 static const char* nativeSctpLib = "libsctp.so.1";
 static jboolean funcsLoaded = JNI_FALSE;
 
+sctp_getladdrs_func* nio_sctp_getladdrs;
+sctp_freeladdrs_func* nio_sctp_freeladdrs;
+sctp_getpaddrs_func* nio_sctp_getpaddrs;
+sctp_freepaddrs_func* nio_sctp_freepaddrs;
+sctp_bindx_func* nio_sctp_bindx;
+sctp_peeloff_func* nio_sctp_peeloff;
+
 JNIEXPORT jint JNICALL DEF_JNI_OnLoad
   (JavaVM *vm, void *reserved) {
     return JNI_VERSION_1_2;


### PR DESCRIPTION
I can't actually build the software yet (due to #4) with these changes. But these fixes definitely need to be backported for it to work with modern Linux distributions. I successfully ran the build past the relevant components using the newest OpenJDK upstream changeset in the repository history (changeset da75f3c4ad5bdf25167a3ed80e51f567ab3dbd01).